### PR TITLE
feat: support `preLaunchTask`,  `Debugger for Microsoft Edge`

### DIFF
--- a/src/UnderlyingDebugAdapter.ts
+++ b/src/UnderlyingDebugAdapter.ts
@@ -1,0 +1,11 @@
+import { extensions, window } from 'vscode'
+
+export function getUnderlyingDebugType(): string {
+    if (!!extensions.getExtension('msjsdiag.debugger-for-chrome')) {
+        return 'chrome'
+    }
+    if (!!extensions.getExtension('msjsdiag.debugger-for-edge')) {
+        return 'edge'
+    }
+    window.showErrorMessage('Install "Debugger for Chrome" or "Debugger for Microsoft Edge" and Reload Window required.')
+}


### PR DESCRIPTION
This PR adds two feature that support `preLaunchTask`,  `Debugger for Microsoft Edge`

- Debug adapter tracker are used to open the webview just before starting the debug session to allow `preLaunchTask`