### PR TITLE
fix: remove extra url space

### DIFF
--- a/client/components/url-input/url-input.tsx
+++ b/client/components/url-input/url-input.tsx
@@ -175,7 +175,7 @@ class UrlInput extends React.Component<any, IUrlInputState> {
   }
 
   private enterUrl() {
-    let url = this.state.url
+    let url = this.state.url.trimLeft()
     const schemeRegex = /^(https?|about|chrome|file):/
 
     if (!url.match(schemeRegex))


### PR DESCRIPTION
When copy a url with space such as ` http://localhost:3000` would add extra http make url `http http://localhost:3000` 