### PR TITLE
fix: add a arg ’--allow-file-access-from-files‘ to fix brower can't open a local file

### DIFF
--- a/src/BrowserClient.ts
+++ b/src/BrowserClient.ts
@@ -23,6 +23,8 @@ export class BrowserClient extends EventEmitter {
 
     chromeArgs.push(`--remote-debugging-port=${this.config.debugPort}`)
 
+    chromeArgs.push(`--allow-file-access-from-files`)
+
     const chromePath = this.config.chromeExecutable || this.getChromiumPath()
 
     if (!chromePath) {


### PR DESCRIPTION
加了一个参数来修复拓展不能打开本地HTML文件的问题 （比如由SingleFileZ.生成的文件）
并且已经本地测试过了，现在是可以打开本地文件了。QwQ 感谢作者制作这么棒的拓展。

Baidu Translate: 
A parameter is added to fix the problem that the extension cannot open the local HTML file (such as the file generated by singlefilez)
And it has been tested locally. Now you can open the local file. QwQ thank the author for such a great expansion.