### PR TITLE
fix: added support to play audio

### DIFF
--- a/src/BrowserClient.ts
+++ b/src/BrowserClient.ts
@@ -43,6 +43,7 @@ export class BrowserClient extends EventEmitter {
       executablePath: chromePath,
       args: chromeArgs,
       ignoreHTTPSErrors,
+      ignoreDefaultArgs: ['--mute-audio'],
     })
 
     // close the initial empty page


### PR DESCRIPTION
Removed the `--mute-audio` argument in headless mode.  
Now it can play audio or play YouTube videos in it.