### PR TITLE
feat: store user data on disk

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
           "default": true,
           "description": "Automatically reload page on local file changes",
           "type": "boolean"
+        },
+        "browse-lite.storeUserData": {
+          "default": true,
+          "description": "Store cookies, localStorage, etc. on disk, so that you don't lose them when you close session. This will help you not get logged out.",
+          "type": "boolean"
         }
       }
     },

--- a/src/BrowserClient.ts
+++ b/src/BrowserClient.ts
@@ -4,15 +4,16 @@ import { existsSync } from 'fs'
 import edge from '@chiragrupani/karma-chromium-edge-launcher'
 import chrome from 'karma-chrome-launcher'
 import puppeteer, { Browser } from 'puppeteer-core'
-import { workspace, window } from 'vscode'
+import { workspace, window, ExtensionContext } from 'vscode'
 import { ExtensionConfiguration } from './ExtensionConfiguration'
 import { tryPort } from './Config'
 import { BrowserPage } from './BrowserPage'
+import { join } from 'path'
 
 export class BrowserClient extends EventEmitter {
   private browser: Browser
 
-  constructor(private config: ExtensionConfiguration) {
+  constructor(private config: ExtensionConfiguration, private ctx: ExtensionContext) {
     super()
   }
 
@@ -41,15 +42,22 @@ export class BrowserClient extends EventEmitter {
 
     const extensionSettings = workspace.getConfiguration('browse-lite')
     const ignoreHTTPSErrors = extensionSettings.get<boolean>('ignoreHttpsErrors')
+    
+    let userDataDir;
+    if (this.config.storeUserData){
+      userDataDir = join(this.ctx.globalStorageUri.fsPath, 'UserData');
+    }
+
     this.browser = await puppeteer.launch({
       executablePath: chromePath,
       args: chromeArgs,
       ignoreHTTPSErrors,
       ignoreDefaultArgs: ['--mute-audio'],
+      userDataDir,
     })
 
-    // close the initial empty page
-    ;(await this.browser.pages()).map(i => i.close())
+      // close the initial empty page
+      ; (await this.browser.pages()).map(i => i.close())
   }
 
   public async newPage(): Promise<BrowserPage> {

--- a/src/BrowserClient.ts
+++ b/src/BrowserClient.ts
@@ -42,9 +42,9 @@ export class BrowserClient extends EventEmitter {
 
     const extensionSettings = workspace.getConfiguration('browse-lite')
     const ignoreHTTPSErrors = extensionSettings.get<boolean>('ignoreHttpsErrors')
-    
+
     let userDataDir;
-    if (this.config.storeUserData){
+    if (this.config.storeUserData) {
       userDataDir = join(this.ctx.globalStorageUri.fsPath, 'UserData');
     }
 
@@ -56,8 +56,8 @@ export class BrowserClient extends EventEmitter {
       userDataDir,
     })
 
-      // close the initial empty page
-      ; (await this.browser.pages()).map(i => i.close())
+    // close the initial empty page
+    ; (await this.browser.pages()).map(i => i.close())
   }
 
   public async newPage(): Promise<BrowserPage> {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -56,5 +56,6 @@ export function getConfigs(ctx: ExtensionContext): ExtensionConfiguration {
     startUrl: getConfig('browse-lite.startUrl', 'https://github.com/antfu/vscode-browse-lite'),
     debugHost: getConfig('browse-lite.debugHost', 'localhost'),
     debugPort: getConfig('browse-lite.debugPort', 9222),
+    storeUserData: getConfig('browse-lite.storeUserData', true),
   }
 }

--- a/src/ExtensionConfiguration.ts
+++ b/src/ExtensionConfiguration.ts
@@ -10,4 +10,5 @@ export interface ExtensionConfiguration {
   isDebug?: boolean
   debugHost: string
   debugPort: number
+  storeUserData: boolean
 }

--- a/src/PanelManager.ts
+++ b/src/PanelManager.ts
@@ -35,7 +35,7 @@ export class PanelManager extends EventEmitter.EventEmitter2 {
     this.refreshSettings()
 
     if (!this.browser)
-      this.browser = new BrowserClient(this.config)
+      this.browser = new BrowserClient(this.config, this.ctx)
 
     const panel = new Panel(this.config, this.browser)
 


### PR DESCRIPTION
Added a setting **Store User Data** that will *Store cookies, localStorage, etc. on disk, so that you don't lose them when you close session. This will help you not get logged out.*

Default is true

If enabled, the puppeteer `UserDataDir` will be set to vscode `GlobalStorageUri / UserData`
and if you login to any site and reopen browse-lite, restart vscode or even after restarting computer *you will still be login to that site like real chrome or any browser*