### PR TITLE
feat: added proxy parameters and expanded browser startup parameters to accommodate some special cases.

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,14 @@
           "default": true,
           "description": "Store cookies, localStorage, etc. on disk, so that you don't lose them when you close session. This will help you not get logged out.",
           "type": "boolean"
+        },
+        "browse-lite.proxy": {
+          "description": "Add proxy parameters during initial loading of the browser.",
+          "type": "string"
+        },
+        "browse-lite.otherArgs": {
+          "description": "Add other parameters during initial loading of the browser.",
+          "type": "string"
         }
       }
     },

--- a/src/BrowserClient.ts
+++ b/src/BrowserClient.ts
@@ -27,6 +27,14 @@ export class BrowserClient extends EventEmitter {
     chromeArgs.push(`--allow-file-access-from-files`)
 
     chromeArgs.push(`--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36`)
+    
+    if(this.config.proxy && this.config.proxy.length>0){
+      chromeArgs.push(`--proxy-server=${this.config.proxy}`)
+    }
+
+    if(this.config.otherArgs && this.config.otherArgs.length>0){
+      chromeArgs.push(this.config.otherArgs)
+    }
 
     const chromePath = this.config.chromeExecutable || this.getChromiumPath()
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -57,5 +57,7 @@ export function getConfigs(ctx: ExtensionContext): ExtensionConfiguration {
     debugHost: getConfig('browse-lite.debugHost', 'localhost'),
     debugPort: getConfig('browse-lite.debugPort', 9222),
     storeUserData: getConfig('browse-lite.storeUserData', true),
+    proxy: getConfig('browse-lite.proxy', ''),
+    otherArgs: getConfig('browse-lite.otherArgs', ''),
   }
 }

--- a/src/ExtensionConfiguration.ts
+++ b/src/ExtensionConfiguration.ts
@@ -11,4 +11,6 @@ export interface ExtensionConfiguration {
   debugHost: string
   debugPort: number
   storeUserData: boolean
+  proxy: string
+  otherArgs: string
 }


### PR DESCRIPTION
We have introduced proxy parameters to the browser startup process to accommodate scenarios where proxy configuration is necessary during debugging. Additionally, we have expanded the browser's startup parameters to allow for the inclusion of other specialized parameters as needed.