### PR TITLE
fix: fix the problem that DevTools cannot be used

### DIFF
--- a/src/BrowserClient.ts
+++ b/src/BrowserClient.ts
@@ -26,6 +26,8 @@ export class BrowserClient extends EventEmitter {
 
     chromeArgs.push(`--allow-file-access-from-files`)
 
+    chromeArgs.push(`--remote-allow-origins=*`)
+
     chromeArgs.push(`--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36`)
     
     if(this.config.proxy && this.config.proxy.length>0){


### PR DESCRIPTION
fix: fix the problem that DevTools cannot be used(Debugging connection was closed. Reason: WebSocket disconnected) (#39)

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

solve the following problems:
<img width="688" alt="image" src="https://user-images.githubusercontent.com/14323022/225794466-4025fd5c-90bd-4422-8ea5-52f066fedc11.png">


### Linked Issues
https://github.com/antfu/vscode-browse-lite/issues/39

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
