### PR TITLE
fix: Synchronize copy/paste between the editor and remote page.

### DIFF
--- a/client/components/screencast/screencast.tsx
+++ b/client/components/screencast/screencast.tsx
@@ -83,7 +83,7 @@ class Screencast extends React.Component<any, any> {
     )
   }
 
-  private handleMouseEvent(event: any) {
+  private handleMouseEvent(event: React.MouseEvent<HTMLImageElement>) {
     if (this.props.isInspectEnabled) {
       if (event.type === 'click') {
         const position = this.convertIntoScreenSpace(event, this.state)
@@ -129,7 +129,9 @@ class Screencast extends React.Component<any, any> {
     }
   }
 
-  private handleKeyEvent(event: any) {
+  private handleKeyEvent(event: React.KeyboardEvent<HTMLImageElement>) {
+    // Prevents events from penetrating into toolbar input
+    event.stopPropagation()
     this.emitKeyEvent(event.nativeEvent)
 
     if (event.key === 'Tab')

--- a/src/BrowserPage.ts
+++ b/src/BrowserPage.ts
@@ -81,10 +81,12 @@ export class BrowserPage extends EnhancedEventEmitter {
       localStorage.setItem('screencastEnabled', 'false')
       localStorage.setItem('panel-selectedTab', 'console')
       // listen copy event
-      document.addEventListener('copy', () => {
+      const copyHandler = () => {
         const text = document?.getSelection()?.toString() ?? ''
         window[InjectEvent.EMIT_BROWSER_LITE_COPY]?.(text)
-      })
+      }
+      document.addEventListener('copy', copyHandler)
+      document.addEventListener('cut', copyHandler)
       function legacyCopy(value) {
         const ta = document.createElement('textarea')
         ta.value = value ?? ''
@@ -96,9 +98,14 @@ export class BrowserPage extends EnhancedEventEmitter {
         ta.remove()
       }
       // listen paste event
-      document.addEventListener('paste', async () => {
+      document.addEventListener('paste', async (event) => {
         const text = await window[InjectEvent.EMIT_BROWSER_LITE_PASTE]()
-        legacyCopy(text)
+        const originText = document?.getSelection()?.toString() ?? ''
+        if (originText === text)
+          return
+        // FIXME Cannot paste manually. need second paste action.
+        legacyCopy(text);
+        (event.target as HTMLInputElement)?.focus()
       })
     })
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
![browser-lite](https://github.com/antfu/vscode-browse-lite/assets/31788042/6b0a4a55-2b24-4376-8b76-11f2a8685025)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
 1.Prevent event penetration to the input box in the toolbar when screencast page input.
 2.Synchronize copy/paste between the editor and remote page.

### Linked Issues
[#46](https://github.com/antfu/vscode-browse-lite/issues/46)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
