### PR TITLE
fix: sync copy and paste

### DIFF
--- a/client/components/screencast/screencast.tsx
+++ b/client/components/screencast/screencast.tsx
@@ -84,6 +84,7 @@ class Screencast extends React.Component<any, any> {
   }
 
   private handleMouseEvent(event: React.MouseEvent<HTMLImageElement>) {
+    event.stopPropagation()
     if (this.props.isInspectEnabled) {
       if (event.type === 'click') {
         const position = this.convertIntoScreenSpace(event, this.state)

--- a/client/components/screencast/screencast.tsx
+++ b/client/components/screencast/screencast.tsx
@@ -148,19 +148,16 @@ class Screencast extends React.Component<any, any> {
 
   private readonly isMac: boolean = /macintosh|mac os x/i.test(navigator.userAgent)
 
-  private readonly clipboardMap = {
-    KeyC: 'document.dispatchEvent(new ClipboardEvent("copy"))',
-    KeyX: 'document.execCommand("cut")', // 'document.dispatchEvent(new ClipboardEvent("cut"))',
-    KeyV: 'document.dispatchEvent(new ClipboardEvent("paste"))',
-  }
-
-  private readonly clipboardCodes = ['KeyC', 'KeyV', 'KeyX'] as const
+  private readonly clipboardMockMap = new Map([
+    ['KeyC', 'document.dispatchEvent(new ClipboardEvent("copy"))'],
+    ['KeyX', 'document.execCommand("cut")'], // 'document.dispatchEvent(new ClipboardEvent("cut"))',
+    ['KeyV', 'document.dispatchEvent(new ClipboardEvent("paste"))'],
+  ])
 
   private emitKeyEvent(event: any) {
     // HACK Simulate macos keyboard event.
-    if (this.isMac && event.metaKey && this.clipboardCodes.includes(event.code)) {
-      const code = event.code as typeof this.clipboardCodes[number]
-      this.props.onInteraction('Runtime.evaluate', { expression: this.clipboardMap[code] })
+    if (this.isMac && event.metaKey && this.clipboardMockMap.has(event.code)) {
+      this.props.onInteraction('Runtime.evaluate', { expression: this.clipboardMockMap.get(event.code) })
       return
     }
 

--- a/client/components/screencast/screencast.tsx
+++ b/client/components/screencast/screencast.tsx
@@ -146,7 +146,24 @@ class Screencast extends React.Component<any, any> {
     return (event.altKey ? 1 : 0) | (event.ctrlKey ? 2 : 0) | (event.metaKey ? 4 : 0) | (event.shiftKey ? 8 : 0)
   }
 
+  private readonly isMac: boolean = /macintosh|mac os x/i.test(navigator.userAgent)
+
+  private readonly clipboardMap = {
+    KeyC: 'document.dispatchEvent(new ClipboardEvent("copy"))',
+    KeyX: 'document.execCommand("cut")', // 'document.dispatchEvent(new ClipboardEvent("cut"))',
+    KeyV: 'document.dispatchEvent(new ClipboardEvent("paste"))',
+  }
+
+  private readonly clipboardCodes = ['KeyC', 'KeyV', 'KeyX'] as const
+
   private emitKeyEvent(event: any) {
+    // HACK Simulate macos keyboard event.
+    if (this.isMac && event.metaKey && this.clipboardCodes.includes(event.code)) {
+      const code = event.code as typeof this.clipboardCodes[number]
+      this.props.onInteraction('Runtime.evaluate', { expression: this.clipboardMap[code] })
+      return
+    }
+
     let type
     switch (event.type) {
       case 'keydown':

--- a/client/components/screencast/screencast.tsx
+++ b/client/components/screencast/screencast.tsx
@@ -83,7 +83,7 @@ class Screencast extends React.Component<any, any> {
     )
   }
 
-  private handleMouseEvent(event: any) {
+  private handleMouseEvent(event: React.MouseEvent<HTMLImageElement>) {
     if (this.props.isInspectEnabled) {
       if (event.type === 'click') {
         const position = this.convertIntoScreenSpace(event, this.state)
@@ -129,7 +129,9 @@ class Screencast extends React.Component<any, any> {
     }
   }
 
-  private handleKeyEvent(event: any) {
+  private handleKeyEvent(event: React.KeyboardEvent<HTMLImageElement>) {
+    // Prevents events from penetrating into toolbar input
+    event.stopPropagation()
     this.emitKeyEvent(event.nativeEvent)
 
     if (event.key === 'Tab')

--- a/src/BrowserPage.ts
+++ b/src/BrowserPage.ts
@@ -94,8 +94,8 @@ export class BrowserPage extends EnhancedEventEmitter {
 
       // sync copy and paste
       if (window[ExposedFunc.EnableCopyPaste]?.()) {
-        const copyHandler = () => {
-          const text = document.getSelection()?.toString()
+        const copyHandler = (event: ClipboardEvent) => {
+          const text = event.clipboardData?.getData('text/plain') || document.getSelection()?.toString()
           text && window[ExposedFunc.EmitCopy]?.(text)
         }
         document.addEventListener('copy', copyHandler)

--- a/src/BrowserPage.ts
+++ b/src/BrowserPage.ts
@@ -81,10 +81,12 @@ export class BrowserPage extends EnhancedEventEmitter {
       localStorage.setItem('screencastEnabled', 'false')
       localStorage.setItem('panel-selectedTab', 'console')
       // listen copy event
-      document.addEventListener('copy', () => {
+      const copyHandler = () => {
         const text = document?.getSelection()?.toString() ?? ''
         window[InjectEvent.EMIT_BROWSER_LITE_COPY]?.(text)
-      })
+      }
+      document.addEventListener('copy', copyHandler)
+      document.addEventListener('cut', copyHandler)
       function legacyCopy(value) {
         const ta = document.createElement('textarea')
         ta.value = value ?? ''
@@ -96,9 +98,14 @@ export class BrowserPage extends EnhancedEventEmitter {
         ta.remove()
       }
       // listen paste event
-      document.addEventListener('paste', async () => {
+      document.addEventListener('paste', async (event) => {
         const text = await window[InjectEvent.EMIT_BROWSER_LITE_PASTE]()
-        legacyCopy(text)
+        const originText = document?.getSelection()?.toString() ?? ''
+        if (originText === text)
+          return
+        // FIXME Cannot paste manually. need second paste action.
+        legacyCopy(text);
+        (event.target as HTMLInputElement)?.focus()
       })
     })
 

--- a/src/BrowserPage.ts
+++ b/src/BrowserPage.ts
@@ -3,6 +3,12 @@ import type { Browser, CDPSession, Page } from 'puppeteer-core'
 import { Clipboard } from './Clipboard'
 import { isDarkTheme } from './Config'
 
+enum ExposedFunc {
+  EmitCopy = 'EMIT_BROWSER_LITE_ON_COPY',
+  GetPaste = 'EMIT_BROWSER_LITE_GET_PASTE',
+  EnableCopyPaste = 'ENABLE_BROWSER_LITE_HOOK_COPY_PASTE',
+}
+
 export class BrowserPage extends EnhancedEventEmitter {
   private client: CDPSession
   private clipboard: Clipboard
@@ -24,7 +30,13 @@ export class BrowserPage extends EnhancedEventEmitter {
     // @ts-expect-error
     this.removeAllListeners()
     this.client.detach()
-    this.page.close()
+    Promise.allSettled([
+      this.page.removeExposedFunction(ExposedFunc.EnableCopyPaste),
+      this.page.removeExposedFunction(ExposedFunc.EmitCopy),
+      this.page.removeExposedFunction(ExposedFunc.GetPaste),
+    ]).then(() => {
+      this.page.close()
+    })
   }
 
   public async send(action: string, data: object = {}, callbackId?: number) {
@@ -69,17 +81,11 @@ export class BrowserPage extends EnhancedEventEmitter {
   }
 
   public async launch(): Promise<void> {
-    enum InjectEvent {
-      HookCopy = 'EMIT_BROWSER_LITE_COPY',
-      HookPaste = 'EMIT_BROWSER_LITE_PASTE',
-      EnableHookCopyPaste = 'ENABLE_HOOK_COPY_PASTE',
-    }
-
-    await Promise.all([
+    await Promise.allSettled([
       // TODO setting for enable sync copy and paste
-      this.page.exposeFunction(InjectEvent.EnableHookCopyPaste, () => true),
-      this.page.exposeFunction(InjectEvent.HookCopy, (text: string) => this.clipboard.writeText(text)),
-      this.page.exposeFunction(InjectEvent.HookPaste, () => this.clipboard.readText()),
+      this.page.exposeFunction(ExposedFunc.EnableCopyPaste, () => true),
+      this.page.exposeFunction(ExposedFunc.EmitCopy, (text: string) => this.clipboard.writeText(text)),
+      this.page.exposeFunction(ExposedFunc.GetPaste, () => this.clipboard.readText()),
     ])
     this.page.evaluateOnNewDocument(() => {
       // custom embedded devtools
@@ -87,16 +93,16 @@ export class BrowserPage extends EnhancedEventEmitter {
       localStorage.setItem('panel-selectedTab', 'console')
 
       // sync copy and paste
-      if (window[InjectEvent.EnableHookCopyPaste]?.()) {
+      if (window[ExposedFunc.EnableCopyPaste]?.()) {
         const copyHandler = () => {
           const text = document.getSelection()?.toString()
-          text && window[InjectEvent.HookCopy]?.(text)
+          text && window[ExposedFunc.EmitCopy]?.(text)
         }
         document.addEventListener('copy', copyHandler)
         document.addEventListener('cut', copyHandler)
         document.addEventListener('paste', async (event) => {
           event.preventDefault()
-          const text = await window[InjectEvent.HookPaste]?.()
+          const text = await window[ExposedFunc.GetPaste]?.()
           text && document.execCommand('insertText', false, text)
         })
       }

--- a/src/BrowserPage.ts
+++ b/src/BrowserPage.ts
@@ -88,7 +88,10 @@ export class BrowserPage extends EnhancedEventEmitter {
 
       // sync copy and paste
       if (window[InjectEvent.EnableHookCopyPaste]?.()) {
-        const copyHandler = () => { window[InjectEvent.HookCopy]?.(document?.getSelection()?.toString() ?? '') }
+        const copyHandler = () => {
+          const text = document.getSelection()?.toString()
+          text && window[InjectEvent.HookCopy]?.(text)
+        }
         document.addEventListener('copy', copyHandler)
         document.addEventListener('cut', copyHandler)
         document.addEventListener('paste', async (event) => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
![browser-lite](https://github.com/antfu/vscode-browse-lite/assets/31788042/6b0a4a55-2b24-4376-8b76-11f2a8685025)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
 1.Prevent event penetration to the input box in the toolbar when screencast page input.
 2.Synchronize copy/paste between the editor and remote page.
 
I have tested it on Windows 11 and macOS 14, and both are running fine.😀

### Linked Issues
fix #46
fix #29
fix #5
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->