### PR TITLE
fix: switching device UA not taking effect and automatically fetch

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -244,7 +244,7 @@ class App extends React.Component<any, IState> {
     return (
       <div className="App">
         {
-        // hide navbar for devtools
+          // hide navbar for devtools
           this.state.isDebug
             ? null
             : (
@@ -505,7 +505,7 @@ class App extends React.Component<any, IState> {
 
   private handleToggleInspect() {
     if (this.state.isInspectEnabled) {
-    // Hide browser highlight
+      // Hide browser highlight
       this.connection.send('Overlay.hideHighlight')
 
       // Hide local highlight
@@ -526,8 +526,13 @@ class App extends React.Component<any, IState> {
   }
 
   private async handleNavigate(url: string) {
+    await this.handleSetUserAgent()
     const data: any = await this.connection.send('Page.navigate', { url })
     this.setState({ url, errorText: data.errorText })
+  }
+
+  private async handleSetUserAgent(userAgent: string = navigator.userAgent) {
+    return this.connection.send('Network.setUserAgentOverride', { userAgent })
   }
 
   private handleViewportSizeChange(data: any) {
@@ -557,6 +562,8 @@ class App extends React.Component<any, IState> {
         height: data.device.viewport.height,
       })
     }
+
+    this.handleSetUserAgent(data.device.userAgent)
   }
 
   private handleToggleDeviceEmulation() {
@@ -599,7 +606,7 @@ class App extends React.Component<any, IState> {
   }
 
   private handleClipboardWrite(data: any) {
-  // overwrite the clipboard only if there is a valid value
+    // overwrite the clipboard only if there is a valid value
     if (data && (data as any).value)
       return this.connection.send('Clipboard.writeText', data)
   }

--- a/src/BrowserClient.ts
+++ b/src/BrowserClient.ts
@@ -30,7 +30,7 @@ export class BrowserClient extends EventEmitter {
 
     chromeArgs.push('--remote-allow-origins=*')
 
-    chromeArgs.push('--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36')
+    // chromeArgs.push('--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36')
 
     if (this.config.proxy && this.config.proxy.length > 0)
       chromeArgs.push(`--proxy-server=${this.config.proxy}`)


### PR DESCRIPTION
Fix the issue of switching devices without setting the user agent; remove hard-coded user agent and change it to automatically retrieve the user agent from the current browser when submitting the URL.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Solve the issue of user agent not taking effect when switching devices in the simulation.
- At the same time, the previous hard-coded userAgent for win10 [1] when the browser starts will be changed to automatically obtain the userAgent of the current device (set navigator.userAgent once when the URL is set).

### Linked Issues

- [1] https://github.com/antfu/vscode-browse-lite/pull/26
- https://github.com/antfu/vscode-browse-lite/issues/35

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
In the `handleSetUserAgent` method, consider adding a check for whether the userAgent has changed to reduce communication for Network.setUserAgentOverride. 